### PR TITLE
Export all methods in a single interface

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [["@babel/env", {"modules": false}]],
   "env": {
     "test": {
-      "plugins": ["transform-es2015-modules-commonjs"]
+      "plugins": ["transform-es2015-modules-commonjs", "dynamic-import-node"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ See _why_ and _when_ to use it by reading the [wiki](https://github.com/luciomar
 ```
 import * as GTagOptIn from 'gtag-opt-in';
 
-const gtag = GTagOptIn.register('1234');
-gtag.optin();
-gtag.optout();
+GTagOptIn.register('1234');
+GTagOptIn.optin();
+GTagOptIn.optout();
 ```
 
 ### HTML
 
 ```
 <script>
-  const gtag = GTagOptIn.register('1234');
-  gtag.optin();
-  gtag.optout();
+  GTagOptIn.register('1234');
+  GTagOptIn.optin();
+  GTagOptIn.optout();
 </script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,22 +19,23 @@ See _why_ and _when_ to use it by reading the [wiki](https://github.com/luciomar
 
     <script src="https://www.npmcdn.com/gtag-opt-in"></script>
 
+It imports the library as the `GTagOptIn` global variable.
+
 ## Use
 
-### JS
+### ES6
 ```
 import * as GTagOptIn from 'gtag-opt-in';
 
-GTagOptIn.register('1234');
+GTagOptIn.register('UA-XXXXXXXXX-Y');
 GTagOptIn.optin();
 GTagOptIn.optout();
 ```
 
 ### HTML
-
 ```
 <script>
-  GTagOptIn.register('1234');
+  GTagOptIn.register('UA-XXXXXXXXX-Y');
   GTagOptIn.optin();
   GTagOptIn.optout();
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3197,6 +3197,37 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es-abstract": {
+      "version": "1.18.0-next.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+      "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.0",
+        "is-negative-zero": "^2.0.0",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "escalade": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
@@ -3942,6 +3973,15 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -4255,6 +4295,12 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "is-callable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "dev": true
+    },
     "is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -4283,6 +4329,12 @@
           }
         }
       }
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -4343,6 +4395,12 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+      "dev": true
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4364,11 +4422,29 @@
       "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -5655,6 +5731,12 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -5671,15 +5753,15 @@
       }
     },
     "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.0",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
       }
     },
     "object.pick": {
@@ -7039,6 +7121,68 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/luciomartinez/gtag-opt-in#readme",
   "devDependencies": {
     "@babel/preset-env": "^7.11.5",
+    "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "jest": "^26.4.2",
     "webpack": "^4.44.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,44 +1,58 @@
-function GTagOptIn(gaMeasurementId) {
-  let isInitialized = false;
+let isInitialized = false;
+let gaMeasurementId = undefined;
 
-  this.gaMeasurementId = gaMeasurementId;
+const register = (gaMeasurementIdValue) => {
+  throwIfInvalidGAMeasurementId(gaMeasurementIdValue);
+  gaMeasurementId = gaMeasurementIdValue;
+};
 
-  this.optout = () => {
-    throwIfGAMeasurementIdIsUndefined();
-    window[`ga-disable-${this.gaMeasurementId}`] = true;
-  };
+const throwIfInvalidGAMeasurementId = (value) => {
+  if (!value) {
+    throw new Error('gtag-opt-in: invalid value passed to `register` method. Make sure to use a valid Analytics ID.');
+  }
+};
 
-  this.optin = () => {
-    throwIfGAMeasurementIdIsUndefined();
-    initGTagIfNeeded();
-    window[`ga-disable-${this.gaMeasurementId}`] = false;
-  };
+const optOut = () => {
+  throwIfUnregistered();
+  window[`ga-disable-${gaMeasurementId}`] = true;
+};
 
-  const throwIfGAMeasurementIdIsUndefined = () => {
-    if (!this.gaMeasurementId) {
-      throw new Error('gtag-opt-in: no value found for Analytics ID. Make sure to initialize properly the object and set its value as a constructor parameter.');
-    }
-  };
+const optIn = () => {
+  throwIfUnregistered();
+  initGTagIfNeeded();
+  window[`ga-disable-${gaMeasurementId}`] = false;
+};
 
-  const initGTagIfNeeded = () => {
-    if (!isInitialized) {
-      initGTag();
-      isInitialized = true;
-    }
-  };
+const throwIfUnregistered = () => {
+  if (!gaMeasurementId) {
+    throw new Error('gtag-opt-in: no value found for Analytics ID. Make sure to register before by calling the `register` method.');
+  }
+};
 
-  const initGTag = () => {
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', this.gaMeasurementId, {'anonymize_ip': true});
-  };
-}
+const initGTagIfNeeded = () => {
+  if (!isInitialized) {
+    initGTag();
+    isInitialized = true;
+  }
+};
 
-const register = (props) => {
-  return new GTagOptIn(props);
+const initGTag = () => {
+  const gtag = getGtagAPI();
+  setInitialValuesToGtag(gtag);
+};
+
+const getGtagAPI = () => {
+  window.dataLayer = window.dataLayer || [];
+  return function(){dataLayer.push(arguments);};
+};
+
+const setInitialValuesToGtag = (gtag) => {
+  gtag('js', new Date());
+  gtag('config', gaMeasurementId, {'anonymize_ip': true});
 };
 
 export {
-  register
+  register,
+  optIn,
+  optOut
 };

--- a/src/test.js
+++ b/src/test.js
@@ -1,11 +1,31 @@
-import * as GTagOptIn from './index';
-
-const GA_MEASUREMENT_ID = 'UA-126456490-1';
-
 describe('GTagOptIn', () => {
+  const GA_MEASUREMENT_ID = 'UA-126456490-1';
+
+  let GTagOptIn;
+
   beforeEach(() => {
     window.dataLayer = undefined;
     window[`ga-disable-${GA_MEASUREMENT_ID}`] = undefined;
+
+    /**
+     * Fixes an issue where module's local variables remain with old values between tests.
+     */
+    return import('./index').then(module => {
+      GTagOptIn = module;
+      jest.resetModules();
+    });
+  });
+
+  test('throw on register without GA Measurement ID', () => {
+    expect(GTagOptIn.register).toThrowError(/Analytics ID/);
+  });
+
+  test('throw on opt-in without previous registration', () => {
+    expect(GTagOptIn.optIn).toThrowError(/Analytics ID/);
+  });
+
+  test('throw on opt-out without previous registration', () => {
+    expect(GTagOptIn.optOut).toThrowError(/Analytics ID/);
   });
 
   test('do NOT define dataLayer on registration', () => {
@@ -19,49 +39,39 @@ describe('GTagOptIn', () => {
   });
 
   test('do NOT modify dataLayer on opt-out', () => {
-    const gtag = GTagOptIn.register(GA_MEASUREMENT_ID);
-    gtag.optout();
+    GTagOptIn.register(GA_MEASUREMENT_ID);
+    GTagOptIn.optOut();
     expect(window.dataLayer).toBeUndefined();
   });
 
-  test('throw on opt-in without GA Measurement ID', () => {
-    const gtag = GTagOptIn.register();
-    expect(gtag.optin).toThrowError(/Analytics ID/);
-  });
-
-  test('throw on opt-out without GA Measurement ID', () => {
-    const gtag = GTagOptIn.register();
-    expect(gtag.optout).toThrowError(/Analytics ID/);
-  });
-
   test('push GA Measurement ID to dataLayer on opt-in', () => {
-    const gtag = GTagOptIn.register(GA_MEASUREMENT_ID);
-    gtag.optin();
+    GTagOptIn.register(GA_MEASUREMENT_ID);
+    GTagOptIn.optIn();
     expect(window.dataLayer[1][1]).toBe(GA_MEASUREMENT_ID);
   });
 
   test('do NOT push GA Measurement ID to dataLayer twice on double opt-in', () => {
-    const gtag = GTagOptIn.register(GA_MEASUREMENT_ID);
-    gtag.optin();
-    gtag.optin();
+    GTagOptIn.register(GA_MEASUREMENT_ID);
+    GTagOptIn.optIn();
+    GTagOptIn.optIn();
     expect(window.dataLayer.length).toBe(2);
   });
 
   test('set config to anonymize IP on opt-in', () => {
-    const gtag = GTagOptIn.register(GA_MEASUREMENT_ID);
-    gtag.optin();
+    GTagOptIn.register(GA_MEASUREMENT_ID);
+    GTagOptIn.optIn();
     expect(window.dataLayer[1][2]).toEqual({'anonymize_ip': true});
   });
 
   test('enable GA on opt-in', () => {
-    const gtag = GTagOptIn.register(GA_MEASUREMENT_ID);
-    gtag.optin();
+    GTagOptIn.register(GA_MEASUREMENT_ID);
+    GTagOptIn.optIn();
     expect(window[`ga-disable-${GA_MEASUREMENT_ID}`]).toBeFalsy();
   });
 
   test('disable GA on opt-out', () => {
-    const gtag = GTagOptIn.register(GA_MEASUREMENT_ID);
-    gtag.optout();
+    GTagOptIn.register(GA_MEASUREMENT_ID);
+    GTagOptIn.optOut();
     expect(window[`ga-disable-${GA_MEASUREMENT_ID}`]).toBeTruthy();
   });
 });

--- a/src/test.js
+++ b/src/test.js
@@ -1,5 +1,5 @@
 describe('GTagOptIn', () => {
-  const GA_MEASUREMENT_ID = 'UA-126456490-1';
+  const GA_MEASUREMENT_ID = 'UA-XXXXXXXXX-Y';
 
   let GTagOptIn;
 


### PR DESCRIPTION
On v1 the usage was a bit tricky since the `register` method returned a new object. Hence, requiring to know two objects structures. On v2 this is simplified to have a single object, `GTagOptIn`, and the methods from the child object is merged at the parent.